### PR TITLE
POC sync reading order in case of vertical_reading_hack is disabled

### DIFF
--- a/2-cre-rotate-japanese-book.lua
+++ b/2-cre-rotate-japanese-book.lua
@@ -53,14 +53,14 @@ end
 ReaderRolling.onPreRenderDocument = function(self)
     -- Let's do it with a setting toggable via the menu item defined above
     isVerticalHackEnabled = self.ui.doc_settings:isTrue("vertical_reading_hack")
-    if not isVerticalHackEnabled then
-        return
-    end    
 
+    -- self.ui.view.inverse_reading_order
     -- Inverse reading order (not sure this is for the best, as ToC items are RTL,
     -- but BookMap and PageBrowser may look as expected)
-    if not self.ui.view.inverse_reading_order then
-        self.ui.view:onToggleReadingOrder()
+    self.ui.view:onToggleReadingOrder(isVerticalHackEnabled)
+
+    if not isVerticalHackEnabled then
+        return
     end
 
     -- Hack a few credocument methods


### PR DESCRIPTION
A patch to address the issue I've raised at https://github.com/plateaukao/koreader_patch_vertical_read/issues/4

This patch will sync the reading order to the value of "vertical_reading_hack" such that in case when vertical_reading is disabled the "original" reading order is restored